### PR TITLE
A-Z listing fix

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -340,7 +340,7 @@ def ProgramsByLetter(url, letter):
     
     pageElement = HTML.ElementFromURL(url + letter)
     
-    for item in pageElement.xpath("//*[@id='atoz-content']//a[@class='tleo']"):
+    for item in pageElement.xpath("//*[@id='atoz-content']//a[contains(@class,'tleo')]"):
         url = item.xpath("./@href")[0]
         
         if not "/iplayer/brand" in url:


### PR DESCRIPTION
The last row on the A-Z listing is missed due to the class being called 'tleo last'