### PR TITLE
Fix iplayer with loss of json schedules and support multi-page listings

### DIFF
--- a/Contents/Code/content.py
+++ b/Contents/Code/content.py
@@ -5,9 +5,7 @@ class Channel(object):
         self.channel_id = channel_id
         self.live_id = live_id
 
-        self.schedule_url = "http://www.bbc.co.uk/%s/programmes/schedules" % (self.channel_id)
-        if region_id:
-            self.schedule_url = self.schedule_url + "/" + region_id
+        self.schedule_url = "http://www.bbc.co.uk/iplayer/schedules/%s" % (self.channel_id)
 
         thumb_url = """http://www.bbc.co.uk/iplayer/img/tv/%s.jpg"""
             


### PR DESCRIPTION
Some programmes on iplayer have more than 20 episodes, and these get split onto multiple pages.  Previously, only the first page of episodes were available via plex.  This retrieves all pages of episodes.

I first noticed this with Glastonbury coverage where there were a LOT of episodes; I looked around to find a current example and came across "Flog It!".  Without this patch I believe Plex is showing less than the 31 episodes available.  http://www.bbc.co.uk/iplayer/episodes/b006mk0g
